### PR TITLE
Remove title from embedded gifs

### DIFF
--- a/layouts/shortcodes/gfycat.html
+++ b/layouts/shortcodes/gfycat.html
@@ -1,1 +1,1 @@
-<div class="gfyitem" data-title=true data-autoplay=true data-controls=true data-expand=true data-id="{{index .Params 0}}" ></div>
+<div class="gfyitem" data-autoplay=true data-controls=true data-expand=true data-id="{{index .Params 0}}" ></div>


### PR DESCRIPTION
Some tips are unreadable on mobile because the title overlays the top part of the gif/video, as seen on the screenshot attached.

![screenshot-spacemacs](https://cloud.githubusercontent.com/assets/1229422/10417607/51d35dde-7042-11e5-83aa-d4efd76978fc.png)
