### PR TITLE
vagrant commands need vagrant layer installed.

### DIFF
--- a/content/posts/vagrant-up.md
+++ b/content/posts/vagrant-up.md
@@ -8,7 +8,9 @@ title: "Start Vagrant"
 
 If you need to run a Vagrant command quickly, check out the commands under `SPC
 V`. They deal with most of the common commands needed when working with Vagrant
-boxes, including tramp SSH. Demonstrated below: `vagrant-up` (`SPC V V`)
+boxes, including tramp SSH. Demonstrated below: `vagrant-up` (`SPC V V`).
+
+You need to have the vagrant layer installed for this to work (https://github.com/syl20bnr/spacemacs/tree/master/layers/+tools/vagrant). Add `vagrant` to the existing `dotspacemacs-configuration-layers` list in your `~/.spacemacs` file.
 
 {{< gfycat KindElderlyDiscus >}}
 


### PR DESCRIPTION
Adds a section explaining that this needs the vagrant layer.
